### PR TITLE
Update Electron and other dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,9 +72,9 @@
 		"productName": "LibreRambox",
 		"appId": "io.github.librerambox",
 		"asar": true,
-		"electronVersion": "25.3.2",
+		"electronVersion": "30.0.1",
 		"electronDownload": {
-			"version": "25.3.2"
+			"version": "30.0.1"
 		},
 		"mac": {
 			"category": "public.app-category.productivity",
@@ -196,26 +196,26 @@
 		}
 	},
 	"devDependencies": {
-		"@electron/asar": "^3.2.4",
-		"@electron/rebuild": "^3.2.13",
-		"electron": "^25.3.2",
-		"electron-builder": "^24.6.3",
-		"electron-packager": "^17.1.1",
-		"mocha": "^10.2.0"
+		"@electron/asar": "^3.2.9",
+		"@electron/rebuild": "^3.6.0",
+		"electron": "^30.0.1",
+		"electron-builder": "^24.13.3",
+		"@electron/packager": "^18.3.2",
+		"mocha": "^10.4.0"
 	},
 	"dependencies": {
-		"@electron/remote": "^2.0.10",
+		"@electron/remote": "^2.1.2",
 		"@exponent/electron-cookies": "2.0.0",
 		"auto-launch": "^5.0.6",
 		"electron-context-menu": "^3.6.1",
 		"electron-dialog": "2.0.0",
 		"electron-is-dev": "^2.0.0",
 		"electron-store": "^8.1.0",
-		"electron-updater": "^6.1.4",
+		"electron-updater": "^6.1.8",
 		"is-online": "^9.0.1",
 		"mime": "3.0.0",
 		"mousetrap": "1.6.5",
-		"tmp": "^0.2.1"
+		"tmp": "^0.2.3"
 	},
 	"volta": {
 		"node": "18.17.0"


### PR DESCRIPTION
It's starting to be harder to upgrade the dependencies since more and more libs are now ES Modules (ESM) only:
- https://www.electronjs.org/docs/latest/tutorial/esm
- https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c

I'm not sure SenchaCmd 6.x supports that.\
In fact it will be better if we use something like webpack which only rely on nodejs, no need to install Java or Ruby.\
But I'm not sure it is possible since LibreRambox seems to heavily rely on ExtJS which seems tightly linked to Sencha.\
(we can open a [discussion](https://github.com/LibreRambox/LibreRambox/discussions) to discuss about that).