### PR TITLE
hangouts chat: incomplete attempt to fix unread message counter

### DIFF
--- a/resources/services.json
+++ b/resources/services.json
@@ -519,7 +519,7 @@
 		"allow_popups": false,
 		"manual_notifications": false,
 		"js_unread": "function checkUnread(){if(document.querySelectorAll(\".akt .XU\").length>0){let e=0;document.querySelectorAll(\".akt .XU\").forEach(t=>e+=t.innerText&&parseInt(t.innerText)),updateBadge(e)}else updateBadge(document.querySelectorAll(\".SSPGKf.EyyDtb.Q6oXP:not(.oCHqfe) .PIw6Oe.EdWvwd.FVKzAb .SaMfhe.m9MHid\").length||0)}function updateBadge(e){1<=e?rambox.setUnreadCount(e):rambox.clearUnreadCount()}setInterval(checkUnread,3e3),window.trustedTypes&&window.trustedTypes.createPolicy&&window.trustedTypes.createPolicy(\"default\",{createHTML:(e,t)=>e});",
-		"userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
+		"userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:131.0) Gecko/20100101 Firefox/131.0",
 		"note": "",
 		"titleBlink": true,
 		"custom_domain": false

--- a/resources/services.json
+++ b/resources/services.json
@@ -518,7 +518,7 @@
 		"type": "messaging",
 		"allow_popups": false,
 		"manual_notifications": false,
-		"js_unread": "function checkUnread(){if(document.querySelectorAll(\".akt .XU\").length>0){let e=0;document.querySelectorAll(\".akt .XU\").forEach(t=>e+=t.innerText&&parseInt(t.innerText)),updateBadge(e)}else updateBadge(document.querySelectorAll(\".SSPGKf.EyyDtb.Q6oXP:not(.oCHqfe) .PIw6Oe.EdWvwd.FVKzAb .SaMfhe.m9MHid\").length||0)}function updateBadge(e){1<=e?rambox.setUnreadCount(e):rambox.clearUnreadCount()}setInterval(checkUnread,3e3),window.trustedTypes&&window.trustedTypes.createPolicy&&window.trustedTypes.createPolicy(\"default\",{createHTML:(e,t)=>e});",
+		"js_unread": "function checkUnread(){var x=document.querySelectorAll('.zY9JEf[jsname=lv4tIb]');if(x.length>0){updateBadge(parseInt(x[0].innerHTML))}else updateBadge(0)}function updateBadge(e){1<=e?rambox.setUnreadCount(e):rambox.clearUnreadCount()}setInterval(checkUnread,3e3),window.trustedTypes&&window.trustedTypes.createPolicy&&window.trustedTypes.createPolicy(\"default\",{createHTML:(e,t)=>e});",
 		"userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:131.0) Gecko/20100101 Firefox/131.0",
 		"note": "",
 		"titleBlink": true,


### PR DESCRIPTION
This PR is an attempt to fix the remaining part of #16, i.e. the icon does not become red since there's no count of unread messages.

However I did not get there yet.

The issue arises because the javascript statement that extracts the number of unread messages and passes that to `updateBadge()` is not working with the current setup of a (logged in) https://chat.google.com webpage (which redirects to https://mail.google.com/chat).

Using the inspector and console in Firefox locally, I could successfully extract this number of messages but **only** after the specific element was clicked/activated with the inspector (example having 2 new messages):

```js
var x=document.querySelectorAll('.zY9JEf[jsname=lv4tIb]'); parseInt(x[0].innerHTML)
2 
```

However with a newly loaded page this does not work. This is probably because the element that I attempt to extract is in a HTML document inside an iframe. (After activating it in the inspector, the console specifically looks in this inner document.)

This is the iframe viewed from the main page:

```js
document.querySelectorAll('#gtn-roster-iframe-id')[0]
<iframe id="gtn-roster-iframe-id" class="ir" name="gtn-roster-iframe-id" tabindex="0" title="Chats" aria-label="Chats" style="" src="https://chat.google.com/…-iframe-id&id=world&pt=6">
```

I could not successfully access its contents:

```js
document.querySelectorAll('#gtn-roster-iframe-id')[0].contentDocument
null
document.querySelectorAll('#gtn-roster-iframe-id')[0].contentWindow
Restricted https://chat.google.com/u/0/frame?shell=9&pt=6&origin=https%3A%2F%2Fmail.google.com#cb=gtn-brain-iframe-id&id=world&pt=6
```

Any ideas how this can be achieved? I found https://stackoverflow.com/a/1088569 but we may be in the cross-origin access case here.

Note that I have no background in JS so most of this was accomplished with trial and error. Any help would be appreciated.
