### PR TITLE
Update User-Agent for Slack in services.json

### DIFF
--- a/resources/services.json
+++ b/resources/services.json
@@ -1194,7 +1194,7 @@
 		"allow_popups": false,
 		"manual_notifications": false,
 		"js_unread": "function checkUnread(){if(document.querySelector(\".p-download_modal__body .p-download_modal__close\")&&document.querySelector(\".p-download_modal__body .p-download_modal__close\").click(),-1!==location.host.indexOf(\"slack.com\")){var e=document.querySelectorAll(\".p-channel_sidebar__channel--unread:not(.p-channel_sidebar__channel--muted)\").length,n=0;document.querySelectorAll(\".p-channel_sidebar__badge:not(.p-channel_sidebar__link_count)\").forEach(e=>{n+=isNaN(parseInt(e.innerHTML))?0:parseInt(e.innerHTML)}),updateBadge(e,n)}}function updateBadge(e,n){var o=0<n?n:0<e?999999:0;rambox.setUnreadCount(o)}setInterval(checkUnread,3e3),0<location.href.indexOf(\"/ssb/redirect?entry_point=workspace_signin\")&&(location.href=location.origin);",
-		"userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36",
+		"userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
 		"note": "",
 		"titleBlink": false,
 		"custom_domain": false


### PR DESCRIPTION
Slack will not allow use in Chrome 129 and older, starting in November 2025.